### PR TITLE
Fix Vignette Build Error

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,7 +46,8 @@ Imports:
     methods,
     utils,
     abind,
-    RNifti (>= 0.9.0)
+    RNifti (>= 0.9.0),
+    rticles
 Enhances: dcemriS4,
     fmri,
     oro.dicom


### PR DESCRIPTION
Adding `rticles` to `Imports` should fix the issue below:
``` 
── Building articles ──────────────────────────────────────────────────────────────────────────────────────
Reading 'vignettes/nifti2.Rmd'
Error : Failed to render RMarkdown
* Error in loadNamespace(name) : there is no package called ‘rticles’
Error: callr subprocess failed: Failed to render RMarkdown
* Error in loadNamespace(name) : there is no package called ‘rticles’
```